### PR TITLE
Casting int w/o rounding will cause problem

### DIFF
--- a/src/main/java/dev/Dev.java
+++ b/src/main/java/dev/Dev.java
@@ -23,7 +23,9 @@ public class Dev {
         if ((numberOfReportsPer24Hours < 0) || (numberOfReportsPer24Hours > 500)) {
             throw new IllegalArgumentException("NumberOfReportsPer24Hours must be between 0 and 500. Was " + numberOfReportsPer24Hours);
         }
-        int res = (int) minutesInADay / numberOfReportsPer24Hours;
+
+        double minutes = minutesInADay / numberOfReportsPer24Hours;
+        int res = (int) Math.round(minutes);
         return String.valueOf(res);
     }
 


### PR DESCRIPTION
If the input parameter is 500, no exception will be thrown, "int res" would be 2,88 before casting to int & will be 2 after. Then if you do the math, "60 / 2 * 24 = 720" reports in 24 hours.